### PR TITLE
Fix for MySQL case sensitivity on UNIX based systems.

### DIFF
--- a/zuul-data/src/main/resources/data/changelog/db.changelog-1.5.xml
+++ b/zuul-data/src/main/resources/data/changelog/db.changelog-1.5.xml
@@ -17,7 +17,7 @@
             <column name="NAME"/>
         </createIndex>
         <sql>
-            INSERT INTO settings (NAME) SELECT DISTINCT NAME FROM settings_group
+            INSERT INTO SETTINGS (NAME) SELECT DISTINCT NAME FROM settings_group
         </sql>
     </changeSet>
     <changeSet author="mcantrell" id="zuul-1.5-settings-group-conversion">


### PR DESCRIPTION
MySQL table names are case sensitive by default in UNIX based systems, which causes changelog 1.5 to fail in UNIX .

See also: https://dev.mysql.com/doc/refman/5.0/en/identifier-case-sensitivity.html